### PR TITLE
fix: use correct scheme and port for UNIFI_HOST in example config

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -6,9 +6,7 @@ services:
     environment:
       CROWDSEC_BOUNCER_API_KEY: MyApiKey
       CROWDSEC_URL: "http://crowdsec:8080/"
-      UNIFI_HOST: "x.x.x.x:8728"
+      UNIFI_HOST: "https://yourunifi:443"
       UNIFI_USER: "api"
       UNIFI_PASS: "password"
     restart: unless-stopped
-
-


### PR DESCRIPTION
Unifi OS doesn't use port `8728` (Probably a leftover from the MicroTik Bouncer) the correct port is `443`