### PR TITLE
Added UNIFI_LOGGING option to enable syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The bouncer configuration is made via environment variables:
 | `UNIFI_IPV4_START_RULE_INDEX` | If you have other custom Rules defined in your Firewall this might need to be changed to prevent collisions        | `22000`                 |    ❌   |
 | `UNIFI_IPV6_START_RULE_INDEX` | If you have other custom Rules defined in your Firewall this might need to be changed to prevent collisions        | `27000`                 |    ❌   |
 | `UNIFI_SKIP_TLS_VERIFY`       | Skips Certificate check for unifi controllers without proper SSL Certificate                                       | `false`                 |    ❌   |
+| `UNIFI_LOGGING`               | Generate Syslog entries when the firewall rules are matched                                                        | `false`                 |    ❌   |
 
 # Contribution
 Any constructive feedback is welcome, fill free to add an issue or a pull request. I will review it and integrate it to the code.

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ var (
 	ipv4StartRuleIndex     int
 	ipv6StartRuleIndex     int
 	skipTLSVerify          bool
+	unifiLogging           bool
 )
 
 func initConfig() {
@@ -32,6 +33,8 @@ func initConfig() {
 	viper.SetDefault("crowdsec_url", "http://crowdsec:8080/")
 	viper.BindEnv("crowdsec_update_interval")
 	viper.SetDefault("crowdsec_update_interval", "5s")
+	viper.BindEnv("crowdsec_origins")
+	viper.SetDefault("crowdsec_origins", nil)
 	viper.BindEnv("unifi_host")
 	viper.BindEnv("unifi_user")
 	viper.BindEnv("unifi_pass")
@@ -49,8 +52,9 @@ func initConfig() {
 	viper.SetDefault("unifi_max_group_size", 10000)
 	viper.BindEnv("unifi_skip_tls_verify")
 	viper.SetDefault("unifi_skip_tls_verify", "false")
-	viper.BindEnv("crowdsec_origins")
-	viper.SetDefault("crowdsec_origins", nil)
+	viper.BindEnv("unifi_logging")
+	viper.SetDefault("unifi_logging", "false")
+	
 
 	logLevel = viper.GetString("log_level")
 	level, err := zerolog.ParseLevel(logLevel)
@@ -94,6 +98,8 @@ func initConfig() {
 	ipv6StartRuleIndex = viper.GetInt("unifi_ipv6_start_rule_index")
 
 	skipTLSVerify = viper.GetBool("unifi_skip_tls_verify")
+
+	unifiLogging = viper.GetBool("unifi_logging")
 
 	all := viper.AllSettings()
 	delete(all, "unifi_pass")

--- a/unifi.go
+++ b/unifi.go
@@ -128,6 +128,7 @@ func (mal *unifiAddrList) postFirewallRule(ctx context.Context, index int, ID st
 		Ruleset:             ruleset,
 		SettingPreference:   "auto",
 		RuleIndex:           startRuleIndex + index,
+		Logging: 		     unifiLogging,
 	}
 
 	if !ipv6 {


### PR DESCRIPTION
You need to delete the existing Firewall Rules for this to take affect.

@GNU-Plus-Windows-User Can you check if this is what you wanted?