### PR TITLE
[improvement] Add UserAgent for proper version management in Hubs

### DIFF
--- a/.github/workflows/container-release.yaml
+++ b/.github/workflows/container-release.yaml
@@ -47,8 +47,10 @@ jobs:
           KO_DOCKER_REPO: ghcr.io/teifun2
           TAGS: ${{ steps.meta.outputs.tags }}
           LABELS: ${{ steps.meta.outputs.labels }}
+          VERSION: ${{ steps.meta.outputs.version }}
           PLATFORMS: linux/amd64,linux/arm64,linux/arm
         run: |
           PTAGS=`echo $TAGS | sed 's/cs-unifi-bouncer://g'`
           export SOURCE_DATE_EPOCH=$(date +%s)
+          export GOFLAGS="-ldflags=-X=main.version=$VERSION"
           ko build -B --image-label "$LABELS" -t "$PTAGS" --platform=$PLATFORMS .

--- a/main.go
+++ b/main.go
@@ -28,7 +28,11 @@ type unifiAddrList struct {
 	modified           bool
 }
 
+// This variable is set by the build process with ldflags
+var version = "unknown"
+
 func main() {
+	log.Info().Msg("Starting cs-unifi-bouncer with version: " + version)
 
 	// zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	initConfig()
@@ -38,6 +42,7 @@ func main() {
 		APIUrl:         crowdsecBouncerURL,
 		TickerInterval: crowdsecUpdateInterval,
 		Origins:        crowdsecOrigins,
+		UserAgent:      fmt.Sprintf("cs-unifi-bouncer/%s", version),
 	}
 	if err := bouncer.Init(); err != nil {
 		log.Fatal().Err(err).Msg("Bouncer init failed")


### PR DESCRIPTION
This should hopefully add the ldflags during the github action so that the application knows which version it is running on.