### PR TITLE
Update Library to contain app_id parsing fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/sync v0.15.0
 )
 
-replace github.com/filipowm/go-unifi => github.com/teifun2/go-unifi v1.8.4
+replace github.com/filipowm/go-unifi => github.com/teifun2/go-unifi v1.8.5
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/teifun2/go-unifi v1.8.4 h1:bVdaFP8uXU0UoDl3/5XhaevBuvF0VeFGAOQx9FQir1A=
-github.com/teifun2/go-unifi v1.8.4/go.mod h1:hf0HZI8SX/h6vEa0BQzxY8Bpm4enbRmrPJ1DFFt6/4A=
+github.com/teifun2/go-unifi v1.8.5 h1:uaZ4/z8wyyRZrtqtxpp7xz4vNQLwf8tG5H7mhILPXA4=
+github.com/teifun2/go-unifi v1.8.5/go.mod h1:hf0HZI8SX/h6vEa0BQzxY8Bpm4enbRmrPJ1DFFt6/4A=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=


### PR DESCRIPTION
Updated the go library so that app_id parsing is done with integer not with string.

This should resolve #26