### PR TITLE
fix: prioritize bouncer deny rules above custom firewall policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The bouncer configuration is made via environment variables:
 | `UNIFI_LOGGING`               | Generate Syslog entries when the firewall rules are matched                                                                               | `false`                 |    ❌    |
 | `UNIFI_ZONE_SRC`              | Space separated list of Source Zones for Firewall Policy in Zone Based mode                                                               | `External`              |    ❌    |
 | `UNIFI_ZONE_DST`              | Space separated list of Destination Zones for Firewall Policy in Zone Based mode                                                          | `Internal Vpn Hotspot`  |    ❌    |
-| `UNIFI_POLICY_REORDERING`     | Enable automatic reordering of firewall policies to ensure cs-unifi-bouncer policies are positioned after default policies                | `true`                  |    ❌    |
+| `UNIFI_POLICY_REORDERING`     | Enable automatic reordering of firewall policies to ensure cs-unifi-bouncer policies have highest priority (before custom and default policies) | `true`                  |    ❌    |
 
 # Contribution
 

--- a/unifi.go
+++ b/unifi.go
@@ -445,14 +445,14 @@ func (mal *unifiAddrList) reorderFirewallPolicies(ctx context.Context) {
 			beforePredefinedIds := make([]string, 0)
 			afterPredefinedIds := make([]string, 0)
 
-			// Extract IDs from pre policies
-			for _, policy := range prePolicies {
+			// Extract IDs from bouncer policies FIRST (highest priority - deny rules)
+			for _, policy := range newPolicies {
 				beforePredefinedIds = append(beforePredefinedIds, policy.ID)
 			}
 
-			// Extract IDs from new policies (go first in after list)
-			for _, policy := range newPolicies {
-				afterPredefinedIds = append(afterPredefinedIds, policy.ID)
+			// Extract IDs from existing custom policies (after bouncer rules)
+			for _, policy := range prePolicies {
+				beforePredefinedIds = append(beforePredefinedIds, policy.ID)
 			}
 
 			// Extract IDs from remaining after policies


### PR DESCRIPTION
The UNIFI_POLICY_REORDERING feature was incorrectly placing bouncer policies in afterPredefinedIds, causing them to appear after custom rules. Bouncer deny rules should have highest priority to block malicious IPs before any other policies are evaluated.