### PR TITLE
fix(logging): explicitly configure zerolog to write to stderr

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 func initConfig() {
 	viper.BindEnv("log_level")
-	viper.SetDefault("log_level", "1")
+	viper.SetDefault("log_level", "info")
 	viper.BindEnv("crowdsec_bouncer_api_key")
 	viper.BindEnv("crowdsec_url")
 	viper.SetDefault("crowdsec_url", "http://crowdsec:8080/")

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/filipowm/go-unifi/unifi"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
@@ -42,6 +44,10 @@ type unifiAddrList struct {
 var version = "unknown"
 
 func main() {
+	// Configure zerolog to write to stderr with no buffering
+	// This ensures logs appear immediately in container environments
+	log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+
 	log.Info().Msg("Starting cs-unifi-bouncer with version: " + version)
 
 	// zerolog.TimeFieldFormat = zerolog.TimeFormatUnix


### PR DESCRIPTION
The default zerolog logger may not flush output immediately in
container environments. Explicitly configure the logger to write
to os.Stderr with timestamps to ensure logs appear in docker/kubectl logs.