### PR TITLE
Add proper Error Message if CrowdsecApi Connection Fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,12 @@ func main() {
 			case <-ctx.Done():
 				log.Error().Msg("terminating bouncer process")
 				return nil
-			case decisions := <-bouncer.Stream:
+			case decisions, ok := <-bouncer.Stream:
+				if !ok {
+					// Stream was closed, likely due to CrowdSec API authentication failure
+					log.Error().Msg("CrowdSec API connection failed (check API key and URL)")
+					return nil
+				}
 				// Reset the inactivity timer
 				inactivityTimer.Reset(time.Second)
 


### PR DESCRIPTION
New error message:

```
{"level":"info","time":"2026-01-03T10:47:37+01:00","message":"Unifi Connection Initialized"}
time="2026-01-03T10:47:38+01:00" level=error msg="API error: access forbidden"
{"level":"error","time":"2026-01-03T10:47:38+01:00","message":"CrowdSec API connection failed (check API key and URL)"}
{"level":"error","error":"bouncer stream halted","time":"2026-01-03T10:47:38+01:00"}
```