### PR TITLE
fix(logging): explicitly configure zerolog to write to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The bouncer configuration is made via environment variables:
 | `CROWDSEC_URL`                | Host and port of CrowdSec agent                                                                                                           | `http://crowdsec:8080/` |    ✅    |
 | `CROWDSEC_ORIGINS`            | Space separated list of CrowdSec origins to filter from LAPI (EG: "crowdsec cscli")                                                       | `none`                  |    ❌    |
 | `CROWDSEC_UPDATE_INTERVAL`    | Interval Frequency Querying the Crowdsec API for changes to the blocklist.                                                                | `5s`                    |    ❌    |
-| `LOG_LEVEL`                   | Minimum log level for bouncer in [zerolog levels](https://pkg.go.dev/github.com/rs/zerolog#readme-leveled-logging)                        | `1`                     |    ❌    |
+| `LOG_LEVEL`                   | Minimum log level for bouncer (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`)                                               | `info`                  |    ❌    |
 | `UNIFI_HOST`                  | Unifi appliance address                                                                                                                   | `none`                  |    ✅    |
 | `UNIFI_API_KEY`               | Unifi appliance API key                                                                                                                   | `none`                  | ✅ / ❌  |
 | `UNIFI_USER`                  | Unifi appliance username                                                                                                                  | `none`                  | ✅ / ❌  |

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 func initConfig() {
 	viper.BindEnv("log_level")
-	viper.SetDefault("log_level", "1")
+	viper.SetDefault("log_level", "info")
 	viper.BindEnv("crowdsec_bouncer_api_key")
 	viper.BindEnv("crowdsec_url")
 	viper.SetDefault("crowdsec_url", "http://crowdsec:8080/")

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/filipowm/go-unifi/unifi"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
@@ -42,6 +44,10 @@ type unifiAddrList struct {
 var version = "unknown"
 
 func main() {
+	// Configure zerolog to write to stderr with no buffering
+	// This ensures logs appear immediately in container environments
+	log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+
 	log.Info().Msg("Starting cs-unifi-bouncer with version: " + version)
 
 	// zerolog.TimeFieldFormat = zerolog.TimeFormatUnix


### PR DESCRIPTION
Copy of #72 

The default zerolog logger may not flush output immediately in
container environments. Explicitly configure the logger to write
to os.Stderr with timestamps to ensure logs appear in docker/kubectl logs.