### PR TITLE
If API returns ErrNotFound then update was succesfulll

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	"github.com/filipowm/go-unifi/unifi"
 	"github.com/rs/zerolog/log"
@@ -162,6 +163,12 @@ func (mal *unifiAddrList) postFirewallGroup(ctx context.Context, ID string, grou
 	}
 
 	if err != nil {
+		// If updating and got "not found", it means no changes were needed (UniFi returns empty data)
+		if ID != "" && errors.Is(err, unifi.ErrNotFound) {
+			log.Debug().Msgf("No update needed for firewall group: %s", groupName)
+			mal.firewallGroups[ipv6][group.Name] = group.ID
+			return group.ID
+		}
 		log.Fatal().Err(err).Msgf("Failed to post firewall group: %v", group)
 		return ""
 	} else {


### PR DESCRIPTION
If Update does not change anything of the group unifi returns empty data. This caused a crash in the unifi library, but can be caught and handled.

Fixes #39 